### PR TITLE
【App】タイマーが正確に1秒をカウントしないバグの修正

### DIFF
--- a/app/Sources/Features/TimerFeature.swift
+++ b/app/Sources/Features/TimerFeature.swift
@@ -69,7 +69,7 @@ struct TimerFeature {
                     let now = ContinuousClock().now
                     let elapsed = Int(start.duration(to: now).components.seconds)
                     await send(.tick(elapsed))
-                    try await Task.sleep(nanoseconds: 300_000_000)
+                    try await Task.sleep(nanoseconds: 100_000_000)
                 }
             }
             .cancellable(id: CancelID.timer)


### PR DESCRIPTION
### issue番号 #57 

### 実装方針
- スタート時刻から何秒経過しているかで経過時間を計算する
1. スタートボタンを押したとき，現在の時刻を記録する
2. 0.3秒ごとに現在時刻との差を計算する
→0.3秒ごとなのは，精度と負荷のバランスを考えると最適だから(処理負荷によっては0.1くらいにもできるかも)
3. 時間が進んでいれば更新する

- この方法にした理由
  - 現在時刻とスタート時刻の差で計算するため，実時間で正確にカウントできる(前の処理ではだんだん誤差が広がっていく)
  - 短時間のバックグラウンドであれば復帰可能