### PR TITLE
【Back】セッション・ラウンド管理の実装

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -297,7 +297,7 @@ curl -X GET http://localhost:8080/api/v1/sessions/{session_id} \
 
 #### セッション完了
 ```bash
-curl -X POST http://localhost:8080/api/v1/sessions/{session_id}/complete \
+curl -X PATCH http://localhost:8080/api/v1/sessions/{session_id}/complete \
   -H "Authorization: Bearer dev-token" \
   -H "Content-Type: application/json"
   ```
@@ -340,7 +340,7 @@ curl -X GET http://localhost:8080/api/v1/rounds/{round_id} \
 
 #### ラウンド完了
 ```bash
-curl -X POST http://localhost:8080/api/v1/rounds/{round_id}/complete \
+curl -X PATCH http://localhost:8080/api/v1/rounds/{round_id}/complete \
   -H "Authorization: Bearer dev-token" \
   -H "Content-Type: application/json" \
   -d '{"focus_score": 85}'
@@ -373,7 +373,7 @@ curl -X POST http://localhost:8080/api/v1/sessions/$SESSION_ID/rounds \
 
 #### ラウンド完了（集中度スコア入力）
 ```bash
-curl -X POST http://localhost:8080/api/v1/rounds/$ROUND_ID/complete \
+curl -X PATCH http://localhost:8080/api/v1/rounds/$ROUND_ID/complete \
   -H "Authorization: Bearer dev-token" \
   -H "Content-Type: application/json" \
   -d '{"focus_score": 90}'
@@ -395,7 +395,7 @@ curl -X POST http://localhost:8080/api/v1/sessions/$SESSION_ID/rounds \
 
 #### 3回目のラウンド完了
 ```bash
-curl -X POST http://localhost:8080/api/v1/rounds/$ROUND_ID/complete \
+curl -X PATCH http://localhost:8080/api/v1/rounds/$ROUND_ID/complete \
   -H "Authorization: Bearer dev-token" \
   -H "Content-Type: application/json" \
   -d '{"focus_score": 95}'
@@ -403,7 +403,7 @@ curl -X POST http://localhost:8080/api/v1/rounds/$ROUND_ID/complete \
 
 #### セッション完了（統計計算）
 ```bash
-curl -X POST http://localhost:8080/api/v1/sessions/$SESSION_ID/complete \
+curl -X PATCH http://localhost:8080/api/v1/sessions/$SESSION_ID/complete \
   -H "Authorization: Bearer dev-token" \
   -H "Content-Type: application/json"
   ```

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -60,7 +60,7 @@ func main() {
 
 	// ここで各リポジトリ、ユースケース、ハンドラーを初期化
 	RepositoryFactory := repository.NewRepositoryFactory(postgresDB, nil, appLogger)
-	useCases := usecase.NewUseCases(RepositoryFactory.Task, appLogger)
+	useCases := usecase.NewUseCases(RepositoryFactory.Task, RepositoryFactory.Session, appLogger)
 	handlers := handler.NewHandlers(useCases, appLogger)
 
 	// サーバー初期化

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -60,7 +60,7 @@ func main() {
 
 	// ここで各リポジトリ、ユースケース、ハンドラーを初期化
 	RepositoryFactory := repository.NewRepositoryFactory(postgresDB, nil, appLogger)
-	useCases := usecase.NewUseCases(RepositoryFactory.Task, RepositoryFactory.Session, appLogger)
+	useCases := usecase.NewUseCases(RepositoryFactory.Task, RepositoryFactory.Session, RepositoryFactory.Round, appLogger)
 	handlers := handler.NewHandlers(useCases, appLogger)
 
 	// サーバー初期化

--- a/backend/internal/app/router.go
+++ b/backend/internal/app/router.go
@@ -49,4 +49,14 @@ func (s *Server) SetupRouter(handlers *handler.Handlers) {
 	sessions.GET("/:session_id", handlers.Session.GetSession)
 	sessions.PATCH("/:session_id/complete", handlers.Session.CompleteSession)
 	sessions.DELETE("/:session_id", handlers.Session.DeleteSession)
+
+	// セッションごとのラウンド関連のルート
+	sessions.POST("/:session_id/rounds", handlers.Round.StartRound)
+	sessions.GET("/:session_id/rounds", handlers.Round.GetAllRoundsBySessionID)
+
+	// ラウンド関連のルート
+	rounds := secured.Group("/rounds")
+	rounds.GET("/:round_id", handlers.Round.GetRound)
+	rounds.PATCH("/:round_id/complete", handlers.Round.CompleteRound)
+	rounds.PATCH("/:round_id/abort", handlers.Round.AbortRound)
 }

--- a/backend/internal/app/router.go
+++ b/backend/internal/app/router.go
@@ -41,4 +41,12 @@ func (s *Server) SetupRouter(handlers *handler.Handlers) {
 	tasks.PATCH("/:task_id/edit", handlers.Task.UpdateTask)
 	tasks.PATCH("/:task_id/toggle", handlers.Task.ToggleTask)
 	tasks.DELETE("/:task_id", handlers.Task.DeleteTask)
+
+	// セッション関連のルート
+	sessions := secured.Group("/sessions")
+	sessions.POST("", handlers.Session.StartSession)
+	sessions.GET("", handlers.Session.GetAllSessions)
+	sessions.GET("/:session_id", handlers.Session.GetSession)
+	sessions.PATCH("/:session_id/complete", handlers.Session.CompleteSession)
+	sessions.DELETE("/:session_id", handlers.Session.DeleteSession)
 }

--- a/backend/internal/domain/model/round.go
+++ b/backend/internal/domain/model/round.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Round はポモドーロラウンドを表す構造体
+type Round struct {
+	ID         uuid.UUID  `db:"id" json:"id"`
+	SessionID  uuid.UUID  `db:"session_id" json:"session_id"`
+	RoundOrder int        `db:"round_order" json:"round_order"`
+	StartTime  time.Time  `db:"start_time" json:"start_time"`
+	EndTime    *time.Time `db:"end_time" json:"end_time,omitempty"`
+	WorkTime   *int       `db:"work_time" json:"work_time,omitempty"`
+	BreakTime  *int       `db:"break_time" json:"break_time,omitempty"`
+	FocusScore *int       `db:"focus_score" json:"focus_score,omitempty"`
+	IsAborted  bool       `db:"is_aborted" json:"is_aborted"`
+	CreatedAt  time.Time  `db:"created_at" json:"created_at"`
+	UpdatedAt  time.Time  `db:"updated_at" json:"updated_at"`
+}
+
+// NewRound は新しいラウンドを作成する
+func NewRound(sessionID uuid.UUID, roundOrder int) *Round {
+	now := time.Now()
+	return &Round{
+		ID:         uuid.New(),
+		SessionID:  sessionID,
+		RoundOrder: roundOrder,
+		StartTime:  now,
+		IsAborted:  false,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+}
+
+// RoundCreateRequest はラウンド作成リクエストを表す
+type RoundCreateRequest struct {
+}
+
+// RoundCompleteRequest はラウンド完了リクエストを表す
+type RoundCompleteRequest struct {
+	FocusScore *int `json:"focus_score" validate:"omitempty,min=0,max=100"`
+}
+
+// RoundResponse はラウンドのレスポンスを表す
+type RoundResponse struct {
+	ID         uuid.UUID  `json:"id"`
+	SessionID  uuid.UUID  `json:"session_id"`
+	RoundOrder int        `json:"round_order"`
+	StartTime  time.Time  `json:"start_time"`
+	EndTime    *time.Time `json:"end_time,omitempty"`
+	WorkTime   *int       `json:"work_time,omitempty"`
+	BreakTime  *int       `json:"break_time,omitempty"`
+	FocusScore *int       `json:"focus_score,omitempty"`
+	IsAborted  bool       `json:"is_aborted"`
+}
+
+// ToResponse はラウンドのドメインモデルをレスポンス形式に変換する
+func (r *Round) ToResponse() *RoundResponse {
+	return &RoundResponse{
+		ID:         r.ID,
+		SessionID:  r.SessionID,
+		RoundOrder: r.RoundOrder,
+		StartTime:  r.StartTime,
+		EndTime:    r.EndTime,
+		WorkTime:   r.WorkTime,
+		BreakTime:  r.BreakTime,
+		FocusScore: r.FocusScore,
+		IsAborted:  r.IsAborted,
+	}
+}
+
+// RoundsResponse はラウンドのリストAPIレスポンスを表す
+type RoundsResponse struct {
+	Rounds []*RoundResponse `json:"rounds"`
+}

--- a/backend/internal/domain/model/session.go
+++ b/backend/internal/domain/model/session.go
@@ -12,7 +12,7 @@ type Session struct {
 	UserID       uuid.UUID  `db:"user_id" json:"user_id"`
 	StartTime    time.Time  `db:"start_time" json:"start_time"`
 	EndTime      *time.Time `db:"end_time" json:"end_time"`
-	AvarageFocus *float64   `db:"avarage_focus" json:"avarage_focus"`
+	AverageFocus *float64   `db:"average_focus" json:"average_focus"`
 	TotaiWorkMin *int       `db:"total_work_min" json:"total_work_min"`
 	RoundCount   *int       `db:"round_count" json:"round_count"`
 	BreakTime    *int       `db:"break_time" json:"break_time"`
@@ -37,7 +37,7 @@ type SessionResponse struct {
 	ID           uuid.UUID  `json:"id"`
 	StartTime    time.Time  `json:"start_time"`
 	EndTime      *time.Time `json:"end_time"`
-	AvarageFocus *float64   `json:"avarage_focus"`
+	AverageFocus *float64   `json:"average_focus"`
 	TotaiWorkMin *int       `json:"total_work_min"`
 	RoundCount   *int       `json:"round_count"`
 	BreakTime    *int       `json:"break_time"`
@@ -49,7 +49,7 @@ func (s *Session) ToResponse() *SessionResponse {
 		ID:           s.ID,
 		StartTime:    s.StartTime,
 		EndTime:      s.EndTime,
-		AvarageFocus: s.AvarageFocus,
+		AverageFocus: s.AverageFocus,
 		TotaiWorkMin: s.TotaiWorkMin,
 		RoundCount:   s.RoundCount,
 		BreakTime:    s.BreakTime,

--- a/backend/internal/domain/model/session.go
+++ b/backend/internal/domain/model/session.go
@@ -1,0 +1,62 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Session はユーザのセッションを表すドメインモデル
+type Session struct {
+	ID           uuid.UUID  `db:"id" json:"id"`
+	UserID       uuid.UUID  `db:"user_id" json:"user_id"`
+	StartTime    time.Time  `db:"start_time" json:"start_time"`
+	EndTime      *time.Time `db:"end_time" json:"end_time"`
+	AvarageFocus *float64   `db:"avarage_focus" json:"avarage_focus"`
+	TotaiWorkMin *int       `db:"total_work_min" json:"total_work_min"`
+	RoundCount   *int       `db:"round_count" json:"round_count"`
+	BreakTime    *int       `db:"break_time" json:"break_time"`
+	CreatedAt    time.Time  `db:"created_at" json:"created_at"`
+	UpdatedAt    time.Time  `db:"updated_at" json:"updated_at"`
+}
+
+// NewSession は新しいセッションを作成する
+func NewSession(userID uuid.UUID) *Session {
+	now := time.Now()
+	return &Session{
+		ID:        uuid.New(),
+		UserID:    userID,
+		StartTime: now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// SessionResponse はセッションのレスポンス形式を表す構造体
+type SessionResponse struct {
+	ID           uuid.UUID  `json:"id"`
+	StartTime    time.Time  `json:"start_time"`
+	EndTime      *time.Time `json:"end_time"`
+	AvarageFocus *float64   `json:"avarage_focus"`
+	TotaiWorkMin *int       `json:"total_work_min"`
+	RoundCount   *int       `json:"round_count"`
+	BreakTime    *int       `json:"break_time"`
+}
+
+// ToResponse はドメインモデルからAPIレスポンス形式に変換する
+func (s *Session) ToResponse() *SessionResponse {
+	return &SessionResponse{
+		ID:           s.ID,
+		StartTime:    s.StartTime,
+		EndTime:      s.EndTime,
+		AvarageFocus: s.AvarageFocus,
+		TotaiWorkMin: s.TotaiWorkMin,
+		RoundCount:   s.RoundCount,
+		BreakTime:    s.BreakTime,
+	}
+}
+
+// SessionsResponse はセッションのリストAPIレスポンス形式を表す構造体
+type SessionsResponse struct {
+	Sessions []*SessionResponse `json:"sessions"`
+}

--- a/backend/internal/domain/repository/round_repository.go
+++ b/backend/internal/domain/repository/round_repository.go
@@ -1,0 +1,32 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/tsunakit99/selfpomodoro/internal/domain/model"
+)
+
+// RoundRepository はラウンドに関するデータベース操作を定義するインターフェース
+type RoundRepository interface {
+	// Create は新しいラウンドを作成する
+	Create(ctx context.Context, round *model.Round) error
+
+	// GetByID は指定されたIDのラウンドを取得する
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Round, error)
+
+	// GetAllBySessionID は指定されたセッションIDのラウンドを取得する
+	GetAllBySessionID(ctx context.Context, sessionID uuid.UUID) ([]*model.Round, error)
+
+	// GetLastBySessionID は指定されたセッションIDの最新のラウンドを取得する
+	GetLastRoundBySessionID(ctx context.Context, sessionID uuid.UUID) (*model.Round, error)
+
+	// Complete はラウンドを完了する
+	Complete(ctx context.Context, id uuid.UUID, focusScore *int, worktime, breaktime int) error
+
+	// AbortRound はラウンドを中止する
+	AbortRound(ctx context.Context, id uuid.UUID) error
+
+	// CalculateSessionState はセッションIDに基づいてラウンドの統計情報を計算する
+	CalculateSessionStats(ctx context.Context, sessionID uuid.UUID) (averageFocus float64, totalWorkMin, roundCount, breakTime int, err error)
+}

--- a/backend/internal/domain/repository/session_repository.go
+++ b/backend/internal/domain/repository/session_repository.go
@@ -1,0 +1,29 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/tsunakit99/selfpomodoro/internal/domain/model"
+)
+
+// SessionRepository はセッション永続化のためのインターフェース
+type SessionRepository interface {
+	// Create は新しいセッションを作成する
+	Create(ctx context.Context, session *model.Session) error
+
+	// GetByID はIDからセッションを取得する
+	GetByID(ctx context.Context, id, userID uuid.UUID) (*model.Session, error)
+
+	// GetAllByUserID はユーザIDからセッションを取得する
+	GetAllByUserID(ctx context.Context, userID uuid.UUID) ([]*model.Session, error)
+
+	// Update はセッションを更新する
+	Update(ctx context.Context, session *model.Session) error
+
+	// Complete はセッションを完了する(終了時刻、平均集中度、総作業時間を設定)
+	Complete(ctx context.Context, id, userID uuid.UUID, averageFocus float64, totalWorkMin, roundCount, breakTime int) error
+
+	// Delete はセッションを削除する
+	Delete(ctx context.Context, id, userID uuid.UUID) error
+}

--- a/backend/internal/infrastructure/repository/postgres/round_repository.go
+++ b/backend/internal/infrastructure/repository/postgres/round_repository.go
@@ -1,0 +1,233 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tsunakit99/selfpomodoro/internal/domain/model"
+	"github.com/tsunakit99/selfpomodoro/internal/domain/repository"
+	"github.com/tsunakit99/selfpomodoro/internal/infrastructure/database"
+	"github.com/tsunakit99/selfpomodoro/internal/infrastructure/logger"
+)
+
+// ラウンドリポジトリに関するエラー
+var (
+	ErrRoundNotFound       = errors.New("ラウンドが見つかりません")
+	ErrRoundCreationFailed = errors.New("ラウンドの作成に失敗しました")
+	ErrRoundUpdateFailed   = errors.New("ラウンドの更新に失敗しました")
+	ErrNoRoundsInSession   = errors.New("セッションにラウンドが存在しません")
+)
+
+// RoundRepositoryImpl はRoundRepositoryインターフェースの実装部分
+type RoundRepositoryImpl struct {
+	db     *database.PostgresDB
+	logger logger.Logger
+}
+
+// NewRoundRepository は新しいRoundRepositoryImplを作成する
+func NewRoundRepository(db *database.PostgresDB, logger logger.Logger) repository.RoundRepository {
+	return &RoundRepositoryImpl{
+		db:     db,
+		logger: logger,
+	}
+}
+
+// Create は新しいラウンドを作成する
+func (r *RoundRepositoryImpl) Create(ctx context.Context, round *model.Round) error {
+	query := `
+		INSERT INTO rounds (id, session_id, round_order, start_time, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		`
+
+	_, err := r.db.DB.ExecContext(ctx, query,
+		round.ID,
+		round.SessionID,
+		round.RoundOrder,
+		round.StartTime,
+		round.CreatedAt,
+		round.UpdatedAt,
+	)
+
+	if err != nil {
+		r.logger.Errorf("ラウンド作成エラー: %v", err)
+		return fmt.Errorf("%w: %v", ErrRoundCreationFailed, err)
+	}
+	return nil
+}
+
+// GetByID は指定されたIDのラウンドを取得する
+// GetByID はIDによってラウンドを取得するメソッド
+func (r *RoundRepositoryImpl) GetByID(ctx context.Context, id uuid.UUID) (*model.Round, error) {
+	query := `
+		SELECT id, session_id, round_order, start_time, end_time, work_time, break_time, focus_score, is_aborted, created_at, updated_at
+		FROM rounds
+		WHERE id = $1
+	`
+
+	var round model.Round
+	err := r.db.DB.GetContext(ctx, &round, query, id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrRoundNotFound
+		}
+		r.logger.Errorf("ラウンド取得エラー: %v", err)
+		return nil, err
+	}
+
+	return &round, nil
+}
+
+// GetAllBySessionID はセッションIDに紐づくすべてのラウンドを取得するメソッド
+func (r *RoundRepositoryImpl) GetAllBySessionID(ctx context.Context, sessionID uuid.UUID) ([]*model.Round, error) {
+	query := `
+		SELECT id, session_id, round_order, start_time, end_time, work_time, break_time, focus_score, is_aborted, created_at, updated_at
+		FROM rounds
+		WHERE session_id = $1
+		ORDER BY round_order ASC
+	`
+
+	var rounds []*model.Round
+	err := r.db.DB.SelectContext(ctx, &rounds, query, sessionID)
+	if err != nil {
+		r.logger.Errorf("ラウンド一覧取得エラー: %v", err)
+		return nil, err
+	}
+	return rounds, nil
+}
+
+// GetLastRoundBySessionID はセッションの最後のラウンドを取得するメソッド
+func (r *RoundRepositoryImpl) GetLastRoundBySessionID(ctx context.Context, sessionID uuid.UUID) (*model.Round, error) {
+	query := `
+		SELECT id, session_id, round_order, start_time, end_time, work_time, break_time, focus_score, is_aborted, created_at, updated_at
+		FROM rounds
+		WHERE session_id = $1
+		ORDER BY round_order DESC
+		LIMIT 1
+	`
+
+	var round model.Round
+	err := r.db.DB.GetContext(ctx, &round, query, sessionID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrNoRoundsInSession
+		}
+		r.logger.Errorf("最終ラウンド取得エラー: %v", err)
+		return nil, err
+	}
+
+	return &round, nil
+}
+
+// Complete はラウンドを完了するメソッド
+func (r *RoundRepositoryImpl) Complete(ctx context.Context, id uuid.UUID, focusScore *int, workTime, breakTime int) error {
+	// ラウンドが存在するか確認
+	_, err := r.GetByID(ctx, id)
+	if err != nil {
+		return err // GetByIDのエラーをそのまま返す
+	}
+
+	query := `
+		UPDATE rounds
+		SET end_time = $1, focus_score = $2, work_time = $3, break_time = $4, updated_at = $5
+		WHERE id = $6
+	`
+
+	_, err = r.db.DB.ExecContext(ctx, query,
+		time.Now(),
+		focusScore,
+		workTime,
+		breakTime,
+		time.Now(),
+		id,
+	)
+	if err != nil {
+		r.logger.Errorf("ラウンド完了エラー: %v", err)
+		return fmt.Errorf("%w: %v", ErrRoundUpdateFailed, err)
+	}
+	return nil
+}
+
+// AbortRound はラウンドを中止としてマークするメソッド
+func (r *RoundRepositoryImpl) AbortRound(ctx context.Context, id uuid.UUID) error {
+	// ラウンドが存在するか確認
+	_, err := r.GetByID(ctx, id)
+	if err != nil {
+		return err // GetByIDのエラーをそのまま返す
+	}
+
+	query := `
+		UPDATE rounds
+		SET end_time = $1, is_aborted = TRUE, updated_at = $2
+		WHERE id = $3
+	`
+
+	_, err = r.db.DB.ExecContext(ctx, query,
+		time.Now(),
+		time.Now(),
+		id,
+	)
+	if err != nil {
+		r.logger.Errorf("ラウンドスキップエラー: %v", err)
+		return fmt.Errorf("%w: %v", ErrRoundUpdateFailed, err)
+	}
+	return nil
+}
+
+// CalculateSessionStats はセッションIDに基づいてラウンドの統計情報を計算するメソッド
+func (r *RoundRepositoryImpl) CalculateSessionStats(ctx context.Context, sessionID uuid.UUID) (float64, int, int, int, error) {
+	// セッションに属するすべての完了済み（スキップされていない）ラウンドを取得
+	query := `
+		SELECT id, session_id, round_order, start_time, end_time, work_time, break_time, focus_score, is_aborted, created_at, updated_at
+		FROM rounds
+		WHERE session_id = $1 AND end_time IS NOT NULL AND is_aborted = FALSE
+		ORDER BY round_order ASC
+	`
+
+	var rounds []*model.Round
+	err := r.db.DB.SelectContext(ctx, &rounds, query, sessionID)
+	if err != nil {
+		r.logger.Errorf("ラウンド統計情報取得エラー: %v", err)
+		return 0, 0, 0, 0, err
+	}
+
+	// ラウンドが無い場合
+	if len(rounds) == 0 {
+		return 0, 0, 0, 0, nil
+	}
+
+	// 統計情報を計算
+	var totalFocus int
+	var validFocusCount int
+	var totalWorkMin int
+	var totalBreakTime int
+
+	for _, round := range rounds {
+		// 集中度の合計（スコアが設定されている場合のみ）
+		if round.FocusScore != nil {
+			totalFocus += *round.FocusScore
+			validFocusCount++
+		}
+
+		// 作業時間の合計
+		if round.WorkTime != nil {
+			totalWorkMin += *round.WorkTime
+		}
+
+		// 休憩時間の合計
+		if round.BreakTime != nil {
+			totalBreakTime += *round.BreakTime
+		}
+	}
+
+	// 平均集中度の計算（スコアが1つ以上ある場合）
+	var averageFocus float64
+	if validFocusCount > 0 {
+		averageFocus = float64(totalFocus) / float64(validFocusCount)
+	}
+
+	return averageFocus, totalWorkMin, len(rounds), totalBreakTime, nil
+}

--- a/backend/internal/infrastructure/repository/postgres/session_repository.go
+++ b/backend/internal/infrastructure/repository/postgres/session_repository.go
@@ -62,7 +62,7 @@ func (r *SessionRepositoryImpl) Create(ctx context.Context, session *model.Sessi
 // GetByID はIDからセッションを取得するメソッド
 func (r *SessionRepositoryImpl) GetByID(ctx context.Context, id, userID uuid.UUID) (*model.Session, error) {
 	query := `
-		SELECT id, user_id, start_time, end_time, avarage_focus, total_work_min, round_count, break_time, created_at, updated_at
+		SELECT id, user_id, start_time, end_time, average_focus, total_work_min, round_count, break_time, created_at, updated_at
 		FROM sessions
 		WHERE id = $1
 	`
@@ -87,7 +87,7 @@ func (r *SessionRepositoryImpl) GetByID(ctx context.Context, id, userID uuid.UUI
 // GetAllByUserID はユーザIDからセッションを取得するメソッド
 func (r *SessionRepositoryImpl) GetAllByUserID(ctx context.Context, userID uuid.UUID) ([]*model.Session, error) {
 	query := `
-		SELECT id, user_id, start_time, end_time, avarage_focus, total_work_min, round_count, break_time, created_at, updated_at
+		SELECT id, user_id, start_time, end_time, average_focus, total_work_min, round_count, break_time, created_at, updated_at
 		FROM sessions
 		WHERE user_id = $1
 		ORDER BY start_time DESC
@@ -112,13 +112,13 @@ func (r *SessionRepositoryImpl) Update(ctx context.Context, session *model.Sessi
 
 	query := `
 		UPDATE sessions
-		SET end_time = $1, avarage_focus = $2, total_work_min = $3, round_count = $4, break_time = $5, updated_at = $6
+		SET end_time = $1, average_focus = $2, total_work_min = $3, round_count = $4, break_time = $5, updated_at = $6
 		WHERE id = $7
 	`
 
 	_, err = r.db.DB.ExecContext(ctx, query,
 		session.EndTime,
-		session.AvarageFocus,
+		session.AverageFocus,
 		session.TotaiWorkMin,
 		session.RoundCount,
 		session.BreakTime,
@@ -146,7 +146,7 @@ func (r *SessionRepositoryImpl) Complete(ctx context.Context, id, userID uuid.UU
 
 	// 計算結果をセット
 	avgFocus := averageFocus
-	session.AvarageFocus = &avgFocus
+	session.AverageFocus = &avgFocus
 
 	totalWork := totalWorkMin
 	session.TotaiWorkMin = &totalWork

--- a/backend/internal/infrastructure/repository/postgres/session_repository.go
+++ b/backend/internal/infrastructure/repository/postgres/session_repository.go
@@ -1,0 +1,182 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tsunakit99/selfpomodoro/internal/domain/model"
+	"github.com/tsunakit99/selfpomodoro/internal/domain/repository"
+	"github.com/tsunakit99/selfpomodoro/internal/infrastructure/database"
+	"github.com/tsunakit99/selfpomodoro/internal/infrastructure/logger"
+)
+
+// セッションリポジトリに関するエラー
+var (
+	ErrSessionNotFound       = errors.New("セッションが見つかりません")
+	ErrSessionAccessDenied   = errors.New("このセッションへのアクセス権限がありません")
+	ErrSessionCreationFailed = errors.New("セッションの作成に失敗しました")
+	ErrSessionUpdateFailed   = errors.New("セッションの更新に失敗しました")
+	ErrSessionDeleteFailed   = errors.New("セッションの削除に失敗しました")
+)
+
+// SessionRepositoryImpl はSessionRepositoryインターフェースの実装部分
+type SessionRepositoryImpl struct {
+	db     *database.PostgresDB
+	logger logger.Logger
+}
+
+// NewSessionRepository は新しいSessionRepositoryImplインスタンスを作成する
+func NewSessionRepository(db *database.PostgresDB, logger logger.Logger) repository.SessionRepository {
+	return &SessionRepositoryImpl{
+		db:     db,
+		logger: logger,
+	}
+}
+
+// Create は新しいセッションを作成するメソッド
+func (r *SessionRepositoryImpl) Create(ctx context.Context, session *model.Session) error {
+	query := `
+		INSERT INTO sessions (id, user_id, start_time, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5)
+	`
+
+	_, err := r.db.DB.ExecContext(ctx, query,
+		session.ID,
+		session.UserID,
+		session.StartTime,
+		session.CreatedAt,
+		session.UpdatedAt,
+	)
+
+	if err != nil {
+		r.logger.Errorf("セッション作成エラー: %v", err)
+		return fmt.Errorf("%w: %v", ErrSessionCreationFailed, err)
+	}
+	return nil
+}
+
+// GetByID はIDからセッションを取得するメソッド
+func (r *SessionRepositoryImpl) GetByID(ctx context.Context, id, userID uuid.UUID) (*model.Session, error) {
+	query := `
+		SELECT id, user_id, start_time, end_time, avarage_focus, total_work_min, round_count, break_time, created_at, updated_at
+		FROM sessions
+		WHERE id = $1
+	`
+
+	var session model.Session
+	err := r.db.DB.GetContext(ctx, &session, query, id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrSessionNotFound
+		}
+		r.logger.Errorf("セッション取得エラー: %v", err)
+		return nil, err
+	}
+
+	// ユーザーIDの確認
+	if session.UserID != userID {
+		return nil, ErrSessionAccessDenied
+	}
+	return &session, nil
+}
+
+// GetAllByUserID はユーザIDからセッションを取得するメソッド
+func (r *SessionRepositoryImpl) GetAllByUserID(ctx context.Context, userID uuid.UUID) ([]*model.Session, error) {
+	query := `
+		SELECT id, user_id, start_time, end_time, avarage_focus, total_work_min, round_count, break_time, created_at, updated_at
+		FROM sessions
+		WHERE user_id = $1
+		ORDER BY start_time DESC
+	`
+
+	var sessions []*model.Session
+	err := r.db.DB.SelectContext(ctx, &sessions, query, userID)
+	if err != nil {
+		r.logger.Errorf("セッション取得エラー: %v", err)
+		return nil, err
+	}
+	return sessions, nil
+}
+
+// Update はセッションを更新するメソッド
+func (r *SessionRepositoryImpl) Update(ctx context.Context, session *model.Session) error {
+	// 最初にセッションの所有者を確認
+	_, err := r.GetByID(ctx, session.ID, session.UserID)
+	if err != nil {
+		return err // GetByIDのエラーをそのまま返す
+	}
+
+	query := `
+		UPDATE sessions
+		SET end_time = $1, avarage_focus = $2, total_work_min = $3, round_count = $4, break_time = $5, updated_at = $6
+		WHERE id = $7
+	`
+
+	_, err = r.db.DB.ExecContext(ctx, query,
+		session.EndTime,
+		session.AvarageFocus,
+		session.TotaiWorkMin,
+		session.RoundCount,
+		session.BreakTime,
+		time.Now(),
+		session.ID,
+	)
+
+	if err != nil {
+		r.logger.Errorf("セッション更新エラー: %v", err)
+		return fmt.Errorf("%w: %v", ErrSessionUpdateFailed, err)
+	}
+	return nil
+}
+
+// Complete はセッションを完了するメソッド
+func (r *SessionRepositoryImpl) Complete(ctx context.Context, id, userID uuid.UUID, averageFocus float64, totalWorkMin, roundCount, breakTime int) error {
+	// 最初にセッションの所有者を確認
+	session, err := r.GetByID(ctx, id, userID)
+	if err != nil {
+		return err // GetByIDのエラーをそのまま返す
+	}
+
+	endTime := time.Now()
+	session.EndTime = &endTime
+
+	// 計算結果をセット
+	avgFocus := averageFocus
+	session.AvarageFocus = &avgFocus
+
+	totalWork := totalWorkMin
+	session.TotaiWorkMin = &totalWork
+
+	rounds := roundCount
+	session.RoundCount = &rounds
+
+	breakT := breakTime
+	session.BreakTime = &breakT
+
+	return r.Update(ctx, session)
+}
+
+// Delete はセッションを削除するメソッド
+func (r *SessionRepositoryImpl) Delete(ctx context.Context, id, userID uuid.UUID) error {
+	// 最初にセッションの所有者を確認
+	_, err := r.GetByID(ctx, id, userID)
+	if err != nil {
+		return err // GetByIDのエラーをそのまま返す
+	}
+
+	query := `
+		DELETE FROM sessions
+		WHERE id = $1
+	`
+
+	_, err = r.db.DB.ExecContext(ctx, query, id)
+	if err != nil {
+		r.logger.Errorf("セッション削除エラー: %v", err)
+		return fmt.Errorf("%w: %v", ErrSessionDeleteFailed, err)
+	}
+	return nil
+}

--- a/backend/internal/infrastructure/repository/repository_factory.go
+++ b/backend/internal/infrastructure/repository/repository_factory.go
@@ -9,7 +9,8 @@ import (
 
 // RepositoryFactory はすべてのリポジトリを管理するファクトリ
 type RepositoryFactory struct {
-	Task repository.TaskRepository
+	Task    repository.TaskRepository
+	Session repository.SessionRepository
 	// TODO: 他のリポジトリを追加する場合はここにフィールドを追加
 }
 
@@ -17,10 +18,12 @@ type RepositoryFactory struct {
 func NewRepositoryFactory(postgresDB *database.PostgresDB, dynamoDB *database.DynamoDB, logger logger.Logger) *RepositoryFactory {
 	// PostgresDBを使用してリポジトリを初期化
 	taskRepo := postgres.NewTaskRepository(postgresDB, logger)
+	sessionRepo := postgres.NewSessionRepository(postgresDB, logger)
 
 	// TODO: DynamoDBを使用してリポジトリを初期化する場合はここに追加
 
 	return &RepositoryFactory{
-		Task: taskRepo,
+		Task:    taskRepo,
+		Session: sessionRepo,
 	}
 }

--- a/backend/internal/infrastructure/repository/repository_factory.go
+++ b/backend/internal/infrastructure/repository/repository_factory.go
@@ -11,6 +11,7 @@ import (
 type RepositoryFactory struct {
 	Task    repository.TaskRepository
 	Session repository.SessionRepository
+	Round   repository.RoundRepository
 	// TODO: 他のリポジトリを追加する場合はここにフィールドを追加
 }
 
@@ -19,11 +20,13 @@ func NewRepositoryFactory(postgresDB *database.PostgresDB, dynamoDB *database.Dy
 	// PostgresDBを使用してリポジトリを初期化
 	taskRepo := postgres.NewTaskRepository(postgresDB, logger)
 	sessionRepo := postgres.NewSessionRepository(postgresDB, logger)
+	roundRepo := postgres.NewRoundRepository(postgresDB, logger)
 
 	// TODO: DynamoDBを使用してリポジトリを初期化する場合はここに追加
 
 	return &RepositoryFactory{
 		Task:    taskRepo,
 		Session: sessionRepo,
+		Round:   roundRepo,
 	}
 }

--- a/backend/internal/interface/handler/handlers.go
+++ b/backend/internal/interface/handler/handlers.go
@@ -10,6 +10,7 @@ type Handlers struct {
 	Auth    *AuthHandler
 	Task    *TaskHandler
 	Session *SessionHandler
+	Round   *RoundHandler
 	// TODO: 他のハンドラーを追加する場合はここにフィールドを追加
 }
 
@@ -19,6 +20,7 @@ func NewHandlers(useCases *usecase.UseCases, logger logger.Logger) *Handlers {
 		Auth:    NewAuthHandler(useCases.Auth, logger),
 		Task:    NewTaskHandler(useCases.Task, logger),
 		Session: NewSessionHandler(useCases.Session, logger),
+		Round:   NewRoundHandler(useCases.Round, logger),
 		// TODO: 他のハンドラーを初期化する場合はここに追加
 	}
 }

--- a/backend/internal/interface/handler/handlers.go
+++ b/backend/internal/interface/handler/handlers.go
@@ -7,16 +7,18 @@ import (
 
 // Handlers はすべてのハンドラーをまとめた構造体
 type Handlers struct {
-	Auth *AuthHandler
-	Task *TaskHandler
+	Auth    *AuthHandler
+	Task    *TaskHandler
+	Session *SessionHandler
 	// TODO: 他のハンドラーを追加する場合はここにフィールドを追加
 }
 
 // NewHandlers はすべてのハンドラーを初期化する
 func NewHandlers(useCases *usecase.UseCases, logger logger.Logger) *Handlers {
 	return &Handlers{
-		Auth: NewAuthHandler(useCases.Auth, logger),
-		Task: NewTaskHandler(useCases.Task, logger),
+		Auth:    NewAuthHandler(useCases.Auth, logger),
+		Task:    NewTaskHandler(useCases.Task, logger),
+		Session: NewSessionHandler(useCases.Session, logger),
 		// TODO: 他のハンドラーを初期化する場合はここに追加
 	}
 }

--- a/backend/internal/interface/handler/round_handler.go
+++ b/backend/internal/interface/handler/round_handler.go
@@ -1,0 +1,191 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/tsunakit99/selfpomodoro/internal/domain/model"
+	"github.com/tsunakit99/selfpomodoro/internal/infrastructure/logger"
+	"github.com/tsunakit99/selfpomodoro/internal/infrastructure/repository/postgres"
+	"github.com/tsunakit99/selfpomodoro/internal/usecase"
+)
+
+// RoundHandler はラウンド関連のエンドポイントを処理するハンドラー
+type RoundHandler struct {
+	roundUseCase usecase.RoundUseCase
+	logger       logger.Logger
+	validator    *validator.Validate
+}
+
+// NewRoundHandler は新しいRoundHandlerインスタンスを作成する
+func NewRoundHandler(roundUseCase usecase.RoundUseCase, logger logger.Logger) *RoundHandler {
+	return &RoundHandler{
+		roundUseCase: roundUseCase,
+		logger:       logger,
+		validator:    validator.New(),
+	}
+}
+
+// getUserIDFromContext はコンテキストからユーザーIDを取得する
+func (h *RoundHandler) getUserIDFromContext(c echo.Context) (uuid.UUID, error) {
+	userID, ok := c.Get("user_id").(string)
+	if !ok {
+		return uuid.Nil, errors.New("ユーザーIDが見つかりません")
+	}
+
+	id, err := uuid.Parse(userID)
+	if err != nil {
+		return uuid.Nil, errors.New("無効なユーザーID")
+	}
+	return id, nil
+}
+
+// StartRound はラウンド開始エンドポイントを処理する
+// POST /sessions/:session_id/rounds
+func (h *RoundHandler) StartRound(c echo.Context) error {
+	// ユーザーIDの取得
+	userID, err := h.getUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": err.Error()})
+	}
+
+	// セッションIDのパース
+	sessionID, err := uuid.Parse(c.Param("session_id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "無効なセッションID"})
+	}
+
+	// リクエストボディのバインド（一旦空でもいい設計）
+	var req model.RoundCreateRequest
+	if err := c.Bind(&req); err != nil {
+		// TODO: RoundCreateRequestの有無を決める
+	}
+
+	// ユースケースを呼び出してラウンドを開始
+	roundResponse, err := h.roundUseCase.StartRound(c.Request().Context(), sessionID, userID, &req)
+	if err != nil {
+		if errors.Is(err, postgres.ErrSessionNotFound) {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "セッションが見つかりません"})
+		}
+		if errors.Is(err, postgres.ErrSessionAccessDenied) {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "このセッションへのアクセス権限がありません"})
+		}
+
+		h.logger.Errorf("ラウンド開始エラー: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "ラウンド開始に失敗しました"})
+	}
+	return c.JSON(http.StatusCreated, roundResponse)
+}
+
+// GetRound はラウンド取得エンドポイントを処理する
+// GET /rounds/:round_id
+func (h *RoundHandler) GetRound(c echo.Context) error {
+	// ラウンドIDのパース
+	roundID, err := uuid.Parse(c.Param("round_id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "無効なラウンドID"})
+	}
+
+	// ユースケースを呼び出してラウンドを取得
+	roundResponse, err := h.roundUseCase.GetRound(c.Request().Context(), roundID)
+	if err != nil {
+		if errors.Is(err, postgres.ErrRoundNotFound) {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "ラウンドが見つかりません"})
+		}
+
+		h.logger.Errorf("ラウンド取得エラー: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "ラウンド取得に失敗しました"})
+	}
+
+	return c.JSON(http.StatusOK, roundResponse)
+}
+
+// GetAllRoundsBySessionID はセッションのラウンド一覧取得エンドポイントを処理する
+// GET /sessions/:session_id/rounds
+func (h *RoundHandler) GetAllRoundsBySessionID(c echo.Context) error {
+	// セッションIDのパース
+	sessionID, err := uuid.Parse(c.Param("session_id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "無効なセッションID"})
+	}
+
+	// ユースケースを呼び出してラウンド一覧を取得
+	roundsResponse, err := h.roundUseCase.GetAllRoundsBySessionID(c.Request().Context(), sessionID)
+	if err != nil {
+		h.logger.Errorf("ラウンド一覧取得エラー: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "ラウンド一覧の取得に失敗しました"})
+	}
+	return c.JSON(http.StatusOK, roundsResponse)
+}
+
+// CompleteRound はラウンド完了エンドポイントを処理する
+// POST /rounds/:round_id/complete
+func (h *RoundHandler) CompleteRound(c echo.Context) error {
+	// ユーザーIDの取得
+	userID, err := h.getUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": err.Error()})
+	}
+
+	// ラウンドIDのパース
+	roundID, err := uuid.Parse(c.Param("round_id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "無効なラウンドID"})
+	}
+
+	// リクエストボディのバインド
+	var req model.RoundCompleteRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "無効なリクエスト形式"})
+	}
+
+	// バリデーション
+	if err := h.validator.Struct(req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "集中度スコアは0から100の間である必要があります"})
+	}
+
+	// ユースケースを呼び出してラウンドを完了
+	roundResponse, err := h.roundUseCase.CompleteRound(c.Request().Context(), roundID, userID, &req)
+	if err != nil {
+		if errors.Is(err, postgres.ErrRoundNotFound) {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "ラウンドが見つかりません"})
+		}
+
+		h.logger.Errorf("ラウンド完了エラー: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "ラウンド完了に失敗しました"})
+	}
+
+	return c.JSON(http.StatusOK, roundResponse)
+}
+
+// AbortRound はラウンド中止エンドポイントを処理する
+// POST /rounds/:round_id/abort
+func (h *RoundHandler) AbortRound(c echo.Context) error {
+	// ユーザーIDの取得
+	userID, err := h.getUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": err.Error()})
+	}
+
+	// ラウンドIDのパース
+	roundID, err := uuid.Parse(c.Param("round_id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "無効なラウンドID"})
+	}
+
+	// ユースケースを呼び出してラウンドを中止
+	roundResponse, err := h.roundUseCase.AbortRound(c.Request().Context(), roundID, userID)
+	if err != nil {
+		if errors.Is(err, postgres.ErrRoundNotFound) {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "ラウンドが見つかりません"})
+		}
+
+		h.logger.Errorf("ラウンド中止エラー: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "ラウンド中止に失敗しました"})
+	}
+
+	return c.JSON(http.StatusOK, roundResponse)
+}

--- a/backend/internal/interface/handler/session_handler.go
+++ b/backend/internal/interface/handler/session_handler.go
@@ -1,0 +1,166 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/tsunakit99/selfpomodoro/internal/infrastructure/logger"
+	"github.com/tsunakit99/selfpomodoro/internal/infrastructure/repository/postgres"
+	"github.com/tsunakit99/selfpomodoro/internal/usecase"
+)
+
+// SessionHandler はセッションに関するHTTPリクエストを処理するハンドラ
+type SessionHandler struct {
+	sessionUseCase usecase.SessionUseCase
+	logger         logger.Logger
+}
+
+// NewSessionHandler は新しいSessionHandlerインスタンスを作成する
+func NewSessionHandler(sessionUseCase usecase.SessionUseCase, logger logger.Logger) *SessionHandler {
+	return &SessionHandler{
+		sessionUseCase: sessionUseCase,
+		logger:         logger,
+	}
+}
+
+// getIUserIDFromContext はコンテキストからユーザIDを取得する
+func (h *SessionHandler) getIUserIDFromContext(c echo.Context) (uuid.UUID, error) {
+	userID, ok := c.Get("user_id").(string)
+	if !ok {
+		return uuid.Nil, errors.New("ユーザIDが取得できません")
+	}
+
+	id, err := uuid.Parse(userID)
+	if err != nil {
+		return uuid.Nil, errors.New("ユーザIDが不正です")
+	}
+	return id, nil
+}
+
+// StartSession は新しいセッション開始エンドポイントを処理する
+// POST /sessions
+func (h *SessionHandler) StartSession(c echo.Context) error {
+	// コンテキストからユーザIDを取得
+	userID, err := h.getIUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": err.Error()})
+	}
+
+	// ユースケースを呼び出してセッションを開始
+	sessionResponse, err := h.sessionUseCase.StartSession(c.Request().Context(), userID)
+	if err != nil {
+		h.logger.Errorf("セッション開始エラー: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "セッションの開始に失敗しました"})
+	}
+	return c.JSON(http.StatusCreated, sessionResponse)
+}
+
+// GetAllSessions は全セッション取得エンドポイントを処理する
+// GET /sessions
+func (h *SessionHandler) GetAllSessions(c echo.Context) error {
+	// コンテキストからユーザIDを取得
+	userID, err := h.getIUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": err.Error()})
+	}
+
+	// ユースケースを呼び出して全セッションを取得
+	sessionsResponse, err := h.sessionUseCase.GetAllSessions(c.Request().Context(), userID)
+	if err != nil {
+		h.logger.Errorf("セッション取得エラー: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "セッションの取得に失敗しました"})
+	}
+	return c.JSON(http.StatusOK, sessionsResponse)
+}
+
+// GetSession はセッション取得エンドポイントを処理する
+// GET /sessions/:session_id
+func (h *SessionHandler) GetSession(c echo.Context) error {
+	// コンテキストからユーザIDを取得
+	userID, err := h.getIUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": err.Error()})
+	}
+
+	// URLパラメータからセッションIDを取得
+	sessionID, err := uuid.Parse(c.Param("session_id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "セッションIDが不正です"})
+	}
+
+	// ユースケースを呼び出してセッションを取得
+	sessionResponse, err := h.sessionUseCase.GetSession(c.Request().Context(), sessionID, userID)
+	if err != nil {
+		if errors.Is(err, postgres.ErrSessionNotFound) {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "セッションが見つかりません"})
+		}
+		if errors.Is(err, postgres.ErrSessionAccessDenied) {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "セッションへのアクセスが拒否されました"})
+		}
+		h.logger.Errorf("セッション取得エラー: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "セッションの取得に失敗しました"})
+	}
+	return c.JSON(http.StatusOK, sessionResponse)
+}
+
+// CompleteSession はセッション完了エンドポイントを処理する
+// POST /sessions/:session_id/complete
+func (h *SessionHandler) CompleteSession(c echo.Context) error {
+	// コンテキストからユーザIDを取得
+	userID, err := h.getIUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": err.Error()})
+	}
+
+	// URLパラメータからセッションIDを取得
+	sessionID, err := uuid.Parse(c.Param("session_id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "セッションIDが不正です"})
+	}
+
+	// ユースケースを呼び出してセッションを完了
+	sessionResponse, err := h.sessionUseCase.CompleteSession(c.Request().Context(), sessionID, userID)
+	if err != nil {
+		if errors.Is(err, postgres.ErrSessionNotFound) {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "セッションが見つかりません"})
+		}
+		if errors.Is(err, postgres.ErrSessionAccessDenied) {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "セッションへのアクセスが拒否されました"})
+		}
+		h.logger.Errorf("セッション完了エラー: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "セッションの完了に失敗しました"})
+	}
+	return c.JSON(http.StatusOK, sessionResponse)
+}
+
+// DeleteSession はセッション削除エンドポイントを処理する
+// DELETE /sessions/:session_id
+func (h *SessionHandler) DeleteSession(c echo.Context) error {
+	// コンテキストからユーザIDを取得
+	userID, err := h.getIUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": err.Error()})
+	}
+
+	// URLパラメータからセッションIDを取得
+	sessionID, err := uuid.Parse(c.Param("session_id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "セッションIDが不正です"})
+	}
+
+	// ユースケースを呼び出してセッションを削除
+	err = h.sessionUseCase.DeleteSession(c.Request().Context(), sessionID, userID)
+	if err != nil {
+		if errors.Is(err, postgres.ErrSessionNotFound) {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "セッションが見つかりません"})
+		}
+		if errors.Is(err, postgres.ErrSessionAccessDenied) {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "セッションへのアクセスが拒否されました"})
+		}
+		h.logger.Errorf("セッション削除エラー: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "セッションの削除に失敗しました"})
+	}
+	return c.NoContent(http.StatusNoContent)
+}

--- a/backend/internal/usecase/session_usecase.go
+++ b/backend/internal/usecase/session_usecase.go
@@ -96,12 +96,11 @@ func (uc *sessionUseCase) CompleteSession(ctx context.Context, id, userID uuid.U
 	}
 
 	// TODO: ラウンドの平均集中度、総作業時間、ラウンド数、休憩時間を計算するロジックを実装
-
-	// ここでは仮の値を設定
-	roundCount := 0
-	totalWorkMin := 0
-	breakTime := 0
-	averageFocus := 0.0
+	averageFocus, totalWorkMin, roundCount, breakTime, err := uc.roundRepo.CalculateSessionStats(ctx, id)
+	if err != nil {
+		uc.logger.Errorf("セッション統計情報取得エラー: %v", err)
+		return nil, err
+	}
 
 	// セッションを完了する
 	err = uc.sessionRepo.Complete(ctx, id, userID, averageFocus, totalWorkMin, roundCount, breakTime)
@@ -110,6 +109,7 @@ func (uc *sessionUseCase) CompleteSession(ctx context.Context, id, userID uuid.U
 		return nil, err
 	}
 
+	// 完了したセッションを取得
 	updatedSession, err := uc.sessionRepo.GetByID(ctx, id, userID)
 	if err != nil {
 		uc.logger.Errorf("セッション取得エラー: %v", err)

--- a/backend/internal/usecase/session_usecase.go
+++ b/backend/internal/usecase/session_usecase.go
@@ -1,0 +1,134 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/tsunakit99/selfpomodoro/internal/domain/model"
+	"github.com/tsunakit99/selfpomodoro/internal/domain/repository"
+	"github.com/tsunakit99/selfpomodoro/internal/infrastructure/logger"
+)
+
+// SessionUseCase はセッションに関するユースケースを定義するインターフェース
+type SessionUseCase interface {
+	// StartSession は新しいセッションを開始する
+	StartSession(ctx context.Context, userID uuid.UUID) (*model.SessionResponse, error)
+
+	// GetSession はセッションを取得する
+	GetSession(ctx context.Context, id, userID uuid.UUID) (*model.SessionResponse, error)
+
+	// GetAllSessions はユーザの全セッションを取得する
+	GetAllSessions(ctx context.Context, userID uuid.UUID) (*model.SessionsResponse, error)
+
+	// CompleteSession はセッションを完了する
+	CompleteSession(ctx context.Context, id, userID uuid.UUID) (*model.SessionResponse, error)
+
+	// DeleteSession はセッションを削除する
+	DeleteSession(ctx context.Context, id, userID uuid.UUID) error
+}
+
+// sessionUseCase はSessionUseCaseインターフェースの実装
+type sessionUseCase struct {
+	sessionRepo repository.SessionRepository
+	roundRepo   repository.RoundRepository
+	logger      logger.Logger
+}
+
+// NewSessionUseCase は新しいSessionUseCaseインスタンスを作成する
+func NewSessionUseCase(sessionRepo repository.SessionRepository, roundRepo repository.RoundRepository, logger logger.Logger) SessionUseCase {
+	return &sessionUseCase{
+		sessionRepo: sessionRepo,
+		roundRepo:   roundRepo,
+		logger:      logger,
+	}
+}
+
+// StartSession は新しいセッションを開始する
+func (uc *sessionUseCase) StartSession(ctx context.Context, userID uuid.UUID) (*model.SessionResponse, error) {
+	session := model.NewSession(userID)
+
+	// DBにセッションを保存
+	if err := uc.sessionRepo.Create(ctx, session); err != nil {
+		uc.logger.Errorf("セッション開始エラー: %v", err)
+		return nil, err
+	}
+
+	// セッションをレスポンス用に変換
+	return session.ToResponse(), nil
+}
+
+// GetSession はセッションを取得する
+func (uc *sessionUseCase) GetSession(ctx context.Context, id, userID uuid.UUID) (*model.SessionResponse, error) {
+	session, err := uc.sessionRepo.GetByID(ctx, id, userID)
+	if err != nil {
+		uc.logger.Errorf("セッション取得エラー: %v", err)
+		return nil, err
+	}
+
+	// セッションをレスポンス用に変換
+	return session.ToResponse(), nil
+}
+
+// GetAllSessions はユーザの全セッションを取得する
+func (uc *sessionUseCase) GetAllSessions(ctx context.Context, userID uuid.UUID) (*model.SessionsResponse, error) {
+	sessions, err := uc.sessionRepo.GetAllByUserID(ctx, userID)
+	if err != nil {
+		uc.logger.Errorf("セッション取得エラー: %v", err)
+		return nil, err
+	}
+
+	// セッションをレスポンス用に変換
+	sessionResponses := make([]*model.SessionResponse, len(sessions))
+	for i, session := range sessions {
+		sessionResponses[i] = session.ToResponse()
+	}
+
+	return &model.SessionsResponse{Sessions: sessionResponses}, nil
+}
+
+// CompleteSession はセッションを完了する
+func (uc *sessionUseCase) CompleteSession(ctx context.Context, id, userID uuid.UUID) (*model.SessionResponse, error) {
+	// セッションを取得
+	_, err := uc.sessionRepo.GetByID(ctx, id, userID)
+	if err != nil {
+		uc.logger.Errorf("セッション取得エラー: %v", err)
+		return nil, err
+	}
+
+	// TODO: ラウンドの平均集中度、総作業時間、ラウンド数、休憩時間を計算するロジックを実装
+
+	// ここでは仮の値を設定
+	roundCount := 0
+	totalWorkMin := 0
+	breakTime := 0
+	averageFocus := 0.0
+
+	// セッションを完了する
+	err = uc.sessionRepo.Complete(ctx, id, userID, averageFocus, totalWorkMin, roundCount, breakTime)
+	if err != nil {
+		uc.logger.Errorf("セッション完了エラー: %v", err)
+		return nil, err
+	}
+
+	updatedSession, err := uc.sessionRepo.GetByID(ctx, id, userID)
+	if err != nil {
+		uc.logger.Errorf("セッション取得エラー: %v", err)
+		return nil, err
+	}
+
+	// TODO: 最適化Lambda実行
+	// TODO: ログの設定と更新
+
+	// セッションをレスポンス用に変換
+	return updatedSession.ToResponse(), nil
+}
+
+// DeleteSession はセッションを削除する
+func (uc *sessionUseCase) DeleteSession(ctx context.Context, id, userID uuid.UUID) error {
+	// セッションを削除
+	if err := uc.sessionRepo.Delete(ctx, id, userID); err != nil {
+		uc.logger.Errorf("セッション削除エラー: %v", err)
+		return err
+	}
+	return nil
+}

--- a/backend/internal/usecase/usecases.go
+++ b/backend/internal/usecase/usecases.go
@@ -7,16 +7,18 @@ import (
 
 // UseCases はすべてのユースケースをまとめた構造体
 type UseCases struct {
-	Auth AuthUseCase
-	Task TaskUseCase
+	Auth    AuthUseCase
+	Task    TaskUseCase
+	Session SessionUseCase
 	// TODO: 他のユースケースを追加する場合はここにフィールドを追加
 }
 
 // NewUseCases はすべてのユースケースを初期化する
-func NewUseCases(taskRepo repository.TaskRepository, logger logger.Logger) *UseCases {
+func NewUseCases(taskRepo repository.TaskRepository, sessionRepo repository.SessionRepository, logger logger.Logger) *UseCases {
 	return &UseCases{
-		Auth: NewAuthUseCase(logger),
-		Task: NewTaskUseCase(taskRepo, logger),
+		Auth:    NewAuthUseCase(logger),
+		Task:    NewTaskUseCase(taskRepo, logger),
+		Session: NewSessionUseCase(sessionRepo, nil, logger),
 		// TODO: 他のユースケースを初期化する場合はここに追加
 	}
 }

--- a/backend/internal/usecase/usecases.go
+++ b/backend/internal/usecase/usecases.go
@@ -19,7 +19,7 @@ func NewUseCases(taskRepo repository.TaskRepository, sessionRepo repository.Sess
 	return &UseCases{
 		Auth:    NewAuthUseCase(logger),
 		Task:    NewTaskUseCase(taskRepo, logger),
-		Session: NewSessionUseCase(sessionRepo, nil, logger),
+		Session: NewSessionUseCase(sessionRepo, roundRepo, logger),
 		Round:   NewRoundUseCase(roundRepo, sessionRepo, logger),
 		// TODO: 他のユースケースを初期化する場合はここに追加
 	}

--- a/backend/internal/usecase/usecases.go
+++ b/backend/internal/usecase/usecases.go
@@ -10,15 +10,17 @@ type UseCases struct {
 	Auth    AuthUseCase
 	Task    TaskUseCase
 	Session SessionUseCase
+	Round   RoundUseCase
 	// TODO: 他のユースケースを追加する場合はここにフィールドを追加
 }
 
 // NewUseCases はすべてのユースケースを初期化する
-func NewUseCases(taskRepo repository.TaskRepository, sessionRepo repository.SessionRepository, logger logger.Logger) *UseCases {
+func NewUseCases(taskRepo repository.TaskRepository, sessionRepo repository.SessionRepository, roundRepo repository.RoundRepository, logger logger.Logger) *UseCases {
 	return &UseCases{
 		Auth:    NewAuthUseCase(logger),
 		Task:    NewTaskUseCase(taskRepo, logger),
 		Session: NewSessionUseCase(sessionRepo, nil, logger),
+		Round:   NewRoundUseCase(roundRepo, sessionRepo, logger),
 		// TODO: 他のユースケースを初期化する場合はここに追加
 	}
 }

--- a/backend/migrations/sql/000003_create_sessions_table.down.sql
+++ b/backend/migrations/sql/000003_create_sessions_table.down.sql
@@ -1,0 +1,3 @@
+-- セッションテーブルの削除
+DROP TRIGGER IF EXISTS sessions_updated_at_trigger ON sessions;
+DROP TABLE IF EXISTS sessions;

--- a/backend/migrations/sql/000003_create_sessions_table.up.sql
+++ b/backend/migrations/sql/000003_create_sessions_table.up.sql
@@ -1,0 +1,22 @@
+-- セッションテーブルの作成
+CREATE TABLE IF NOT EXISTS sessions (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    start_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    end_time TIMESTAMP WITH TIME ZONE,
+    average_focus FLOAT,
+    total_work_min INTEGER,
+    round_count INTEGER DEFAULT 0,
+    break_time INTEGER,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- インデックスの作成
+CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
+
+-- トリガーの設定
+CREATE TRIGGER sessions_updated_at_trigger
+BEFORE UPDATE ON sessions
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();

--- a/backend/migrations/sql/000004_create_rounds_table.down.sql
+++ b/backend/migrations/sql/000004_create_rounds_table.down.sql
@@ -1,0 +1,3 @@
+-- ラウンドテーブルの削除
+DROP TRIGGER IF EXISTS rounds_updated_at_trigger ON rounds;
+DROP TABLE IF EXISTS rounds;

--- a/backend/migrations/sql/000004_create_rounds_table.up.sql
+++ b/backend/migrations/sql/000004_create_rounds_table.up.sql
@@ -1,0 +1,24 @@
+-- ラウンドテーブルの作成
+CREATE TABLE IF NOT EXISTS rounds (
+    id UUID PRIMARY KEY,
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    round_order INTEGER NOT NULL,
+    start_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    end_time TIMESTAMP WITH TIME ZONE,
+    work_time INTEGER,
+    break_time INTEGER,
+    focus_score INTEGER,
+    is_skipped BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- インデックスの作成
+CREATE INDEX IF NOT EXISTS idx_rounds_session_id ON rounds(session_id);
+CREATE INDEX IF NOT EXISTS idx_rounds_session_id_round_order ON rounds(session_id, round_order);
+
+-- トリガーの設定
+CREATE TRIGGER rounds_updated_at_trigger
+BEFORE UPDATE ON rounds
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();

--- a/backend/migrations/sql/000005_rename_is_skipped_to_is_aborted.down.sql
+++ b/backend/migrations/sql/000005_rename_is_skipped_to_is_aborted.down.sql
@@ -1,0 +1,2 @@
+-- is_aborted カラムを is_skipped に戻す
+ALTER TABLE rounds RENAME COLUMN is_aborted TO is_skipped;

--- a/backend/migrations/sql/000005_rename_is_skipped_to_is_aborted.up.sql
+++ b/backend/migrations/sql/000005_rename_is_skipped_to_is_aborted.up.sql
@@ -1,0 +1,2 @@
+-- is_skipped カラムを is_aborted に名前変更
+ALTER TABLE rounds RENAME COLUMN is_skipped TO is_aborted;


### PR DESCRIPTION
# 概要
## 主な実装
- セッションテーブル、ラウンドテーブルの作成
- セッション開始・完了等のエンドポイント
- ラウンド開始・完了等のエンドポイント
- セッション終了後の平均集中度スコアや総作業時間などの計算機構