### PR TITLE
【Back】動作確認用に作業時間、休憩時間のデフォルトを短縮

### DIFF
--- a/backend/internal/usecase/round_usecase.go
+++ b/backend/internal/usecase/round_usecase.go
@@ -135,8 +135,8 @@ func (uc *roundUseCase) CompleteRound(ctx context.Context, id uuid.UUID, userID 
 	// 現在のラウンドの作業時間と休憩時間を取得
 	// TODO: 将来的にはDynamoDBのuser_configsから取得
 	// 現時点ではデフォルト値を使用
-	workTime := 0.5 // デフォルト: 5分
-	breakTime := 0.1 // デフォルト: 0.1分
+	workTime := 1 // デフォルト: 1分
+	breakTime := 1 // デフォルト: 1分
 
 	// ラウンドを完了する
 	if err := uc.roundRepo.Complete(ctx, id, req.FocusScore, workTime, breakTime); err != nil {

--- a/backend/internal/usecase/round_usecase.go
+++ b/backend/internal/usecase/round_usecase.go
@@ -135,8 +135,8 @@ func (uc *roundUseCase) CompleteRound(ctx context.Context, id uuid.UUID, userID 
 	// 現在のラウンドの作業時間と休憩時間を取得
 	// TODO: 将来的にはDynamoDBのuser_configsから取得
 	// 現時点ではデフォルト値を使用
-	workTime := 25 // デフォルト: 25分
-	breakTime := 5 // デフォルト: 5分
+	workTime := 0.5 // デフォルト: 5分
+	breakTime := 0.1 // デフォルト: 0.1分
 
 	// ラウンドを完了する
 	if err := uc.roundRepo.Complete(ctx, id, req.FocusScore, workTime, breakTime); err != nil {


### PR DESCRIPTION
モバイル側で動作確認するときに毎回25分待つのが大変だったので、デフォルトを短くしたいです！！

<img width="429" alt="image" src="https://github.com/user-attachments/assets/6eb9edc0-021f-4b61-8c04-26f4a6e13421" />

### 想定
以下のコマンドを実行したときに短縮されたデフォルトの時間でタイマーがセットされる
```
curl -X POST http://localhost:8080/api/v1/sessions/$SESSION_ID/rounds \
  -H "Authorization: Bearer dev-token" \
  -H "Content-Type: application/json"
```